### PR TITLE
Fix conversation API integration and session handling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,30 +18,34 @@ import {
   handleRecommendedQuery, 
   handleSendMessage 
 } from "./components/ChatService";
+import { getConversation } from "./api/conversationDetailsApi";
+import { endConversation } from "./api/conversationEndApi";
 import transitionBg1 from "./assets/b7849cb38b3409941691afb7821cfd234223c641.png";
 import transitionBg2 from "./assets/66ec66f92d58f4ce9239f67f34f6b8ad2abaa407.png";
 import transitionBg3 from "./assets/acace210f12a3f453253423209de0aa1f9f356c7.png";
 import Recorder from "./components/Recorder";
 import { startConversation } from "./api/conversationsApi";
+
 export default function App() {
-  const [language, setLanguage] = useState('ko');
-  const [currentPage, setCurrentPage] = useState('home');
+  const [language, setLanguage] = useState("ko");
+  const [currentPage, setCurrentPage] = useState("home");
   const [selectedCharacter, setSelectedCharacter] = useState(null);
   const [hoveredCharacter, setHoveredCharacter] = useState(null);
   const [isTransitioning, setIsTransitioning] = useState(false);
   const [messages, setMessages] = useState([]);
-  const [inputMessage, setInputMessage] = useState('');
+  const [inputMessage, setInputMessage] = useState("");
   const [transitionBackground, setTransitionBackground] = useState(null);
   const [selectedFavoriteArt, setSelectedFavoriteArt] = useState(null);
   const [showPhotoCard, setShowPhotoCard] = useState(false);
+  const [conversationId, setConversationId] = useState(null);
 
   // 시간 포맷 함수
   const formatTime = (date) => {
-    if (language === 'en') {
-      return date.toLocaleTimeString('en-US', { 
-        hour: 'numeric', 
-        minute: '2-digit',
-        hour12: true 
+    if (language === "en") {
+      return date.toLocaleTimeString("en-US", {
+        hour: "numeric",
+        minute: "2-digit",
+        hour12: true,
       });
     } else {
       return date.toLocaleTimeString();
@@ -52,29 +56,32 @@ export default function App() {
 
   // 채팅 페이지 진입 시 환영 메시지 자동 생성
   useEffect(() => {
-    if (currentPage === 'chat' && selectedCharacter && messages.length === 0) {
+    if (currentPage === "chat" && selectedCharacter && messages.length === 0) {
       const welcomeMessage = {
         id: 1,
-        type: 'guide',
-        content: language === 'en' 
-          ? `Hello! I'm ${selectedCharacter.nameEn}, your personal guide at the National Museum of Korea. I'm excited to help you explore our amazing collection! What would you like to know about?`
-          : `안녕하세요! 저는 국립중앙박물관의 가이드 ${selectedCharacter.name}입니다. 오늘 국립중앙박물관에 오신 것을 환영해요! 궁금한 것이 있으시면 언제든 물어보세요.`,
-        timestamp: formatTime(new Date())
+        type: "guide",
+        content:
+          language === "en"
+            ? `Hello! I'm ${selectedCharacter.nameEn}, your personal guide at the National Museum of Korea. I'm excited to help you explore our amazing collection! What would you like to know about?`
+            : `안녕하세요! 저는 국립중앙박물관의 가이드 ${selectedCharacter.name}입니다. 오늘 국립중앙박물관에 오신 것을 환영해요! 궁금한 것이 있으시면 언제든 물어보세요.`,
+        timestamp: formatTime(new Date()),
       };
       setMessages([welcomeMessage]);
     }
   }, [currentPage, selectedCharacter, language, messages.length]);
 
   const handleStartGuide = () => {
-    setCurrentPage('highlights');
+    setCurrentPage("highlights");
   };
-  
+
   const handleStartChat = () => {
-    setCurrentPage('character-select');
+    setCurrentPage("character-select");
   };
+
   const handleCharacterSelect = (character) => {
     setSelectedCharacter(character);
   };
+
   const handleConfirm = () => {
     if (selectedCharacter) {
       // 랜덤 배경 이미지 선택
@@ -84,85 +91,142 @@ export default function App() {
       setIsTransitioning(true);
       // 전환 효과 후 채팅 페이지로 이동
       setTimeout(() => {
-        setCurrentPage('chat');
+        setCurrentPage("chat");
         setIsTransitioning(false);
         setTransitionBackground(null);
+
         // 대화 세션 시작 및 시스템 메시지 + 환영 메시지 추가
         (async () => {
-          const res = await startConversation({ body: { language } });
+          try {
+            const res = await startConversation();
 
-          const welcomeMessage = {
-            id: 2,
-            type: 'guide',
-            content: language === 'en' 
-              ? `Hello! I'm ${selectedCharacter.nameEn}. I'll help you explore the National Museum of Korea today. Feel free to ask me anything!`
-              : `안녕하세요! 저는 ${selectedCharacter.name}입니다. 오늘 국립중앙박물관 관람을 도와드리겠습니다. 궁금한 것이 있으시면 언제든 물어보세요!`,
-            timestamp: formatTime(new Date())
-          };
+            const messagesToSet = [];
+            if (res?.success && res?.data && 'session_id' in res.data) {
+              const sessionId = res.data.session_id;
+              setConversationId(sessionId);
 
-          const messagesToSet = [];
-          if (res?.success && res?.data?.sessionId != null) {
-            const sessionId = res.data.sessionId;
-            messagesToSet.push({
-              id: 1,
-              type: 'system',
-              content: language === 'en'
-                ? `Chat ID ${sessionId} has joined the conversation.`
-                : `채팅 ID ${sessionId}이 대화에 참여했습니다.`,
-              timestamp: formatTime(new Date())
-            });
-          } else {
-            console.error('startConversation failed:', res);
-            messagesToSet.push({
-              id: 1,
-              type: 'system',
-              content: language === 'en'
-                ? 'Failed to start a chat session. Starting in offline mode.'
-                : '세션 시작에 실패했습니다. 오프라인 모드로 진행합니다.',
-              timestamp: formatTime(new Date())
-            });
+              messagesToSet.push({
+                id: 1,
+                type: "system",
+                content:
+                  language === "en"
+                    ? `Chat session ${sessionId} started.`
+                    : `채팅 세션 ${sessionId}이 시작되었습니다.`,
+                timestamp: formatTime(new Date()),
+              });
+
+              // 기존 대화 기록 불러오기 시도 (실패해도 괜찮음 - 첫 대화일 수 있음)
+              try {
+                const history = await getConversation(sessionId, { page: 0, size: 20 });
+                if (
+                  history?.success &&
+                  Array.isArray(history?.data?.messages) &&
+                  history.data.messages.length > 0
+                ) {
+                  history.data.messages.forEach((m) => {
+                    messagesToSet.push({
+                      id: messagesToSet.length + 1,
+                      type: m.role?.toLowerCase() === "user" ? "user" : "guide",
+                      content: m.content,
+                      timestamp: formatTime(new Date(m.createdAt || Date.now())),
+                    });
+                  });
+                }
+              } catch (historyError) {
+                // 기록 불러오기 실패는 정상 (첫 대화일 가능성)
+                console.log("📝 No conversation history found (first chat):", historyError.message);
+              }
+            } else {
+              console.error("❌ startConversation failed:", res);
+              messagesToSet.push({
+                id: 1,
+                type: "system",
+                content:
+                  language === "en"
+                    ? "Failed to start a chat session. Starting in offline mode."
+                    : "세션 시작에 실패했습니다. 오프라인 모드로 진행합니다.",
+                timestamp: formatTime(new Date()),
+              });
+            }
+
+            // 기록이 없으면 환영 메시지 추가
+            if (!messagesToSet.some((msg) => msg.type === "guide")) {
+              messagesToSet.push({
+                id: messagesToSet.length + 1,
+                type: "guide",
+                content:
+                  language === "en"
+          ? `Hello! I'm ${selectedCharacter.nameEn}. I'll help you explore the National Museum of Korea today. Feel free to ask me anything!`
+                    : `안녕하세요! 저는 ${selectedCharacter.name}입니다. 오늘 국립중앙박물관 관람을 도와드리겠습니다. 궁금한 것이 있으시면 언제든 물어보세요!`,
+                timestamp: formatTime(new Date()),
+              });
+            }
+            setMessages(messagesToSet);
+          } catch (err) {
+            console.error("🔥 startConversation error:", err);
+        setMessages([
+          {
+            id: 1,
+                type: "system",
+                content:
+                  language === "en"
+                    ? "Error occurred while starting session."
+                    : "세션 시작 중 오류가 발생했습니다.",
+                timestamp: formatTime(new Date()),
+              },
+            ]);
           }
-
-          messagesToSet.push(welcomeMessage);
-          setMessages(messagesToSet);
         })();
       }, 1500);
     }
   };
+
   const handleBackToGuideSelect = () => {
-    setCurrentPage('character-select');
+    setCurrentPage("character-select");
     setMessages([]);
+    setConversationId(null);
   };
+
   const handleBackToHome = () => {
-    setCurrentPage('home');
+    setCurrentPage("home");
     setSelectedCharacter(null);
     setSelectedFavoriteArt(null);
     setShowPhotoCard(false);
+    setConversationId(null);
   };
-  const handleEndChat = () => {
-    setCurrentPage('summary');
+
+  const handleEndChat = async () => {
+    if (conversationId) {
+      try {
+        await endConversation(conversationId, { reason: "USER_REQUEST" });
+      } catch (e) {
+        console.error("endConversation failed", e);
+      }
+    }
+    setCurrentPage("summary");
   };
-  if (currentPage === 'home') {
+
+  // --- 렌더링 ---
+  if (currentPage === "home") {
     return (
-      <LandingPage 
-        language={language} 
+      <LandingPage
+        language={language}
         onStartGuide={handleStartGuide}
         onLanguageChange={setLanguage}
       />
     );
   }
 
-  // 하이라이트 페이지
-  if (currentPage === 'highlights') {
+  if (currentPage === "highlights") {
     return (
       <HighlightsPage
         language={language}
         onStartChat={handleStartChat}
-        onBackToHome={() => setCurrentPage('home')}
+        onBackToHome={() => setCurrentPage("home")}
       />
     );
   }
-  // 전환 효과
+
   if (isTransitioning) {
     return (
       <TransitionEffect
@@ -174,8 +238,7 @@ export default function App() {
     );
   }
 
-  // 채팅 페이지
-  if (currentPage === 'chat') {
+  if (currentPage === "chat") {
     return (
       <ChatPage
         language={language}
@@ -184,17 +247,46 @@ export default function App() {
         inputMessage={inputMessage}
         setInputMessage={setInputMessage}
         handleBackToGuideSelect={handleBackToGuideSelect}
-        handleSendMessage={(inputMessage) => handleSendMessage(inputMessage, setInputMessage, messages, setMessages, selectedCharacter, language, formatTime)}
-        handleLearnMore={(messageContent) => handleLearnMore(messageContent, language, selectedCharacter, messages, setMessages, formatTime)}
+        handleSendMessage={(inputMessage) =>
+          handleSendMessage(
+            inputMessage,
+            setInputMessage,
+            messages,
+            setMessages,
+            selectedCharacter,
+            language,
+            formatTime,
+            conversationId
+          )
+        }
+        handleLearnMore={(messageContent) =>
+          handleLearnMore(
+            messageContent,
+            language,
+            selectedCharacter,
+            messages,
+            setMessages,
+            formatTime
+          )
+        }
         handleEndChat={handleEndChat}
-        handleRecommendedQuery={(query) => handleRecommendedQuery(query, language, selectedCharacter, messages, setMessages, setInputMessage, formatTime)}
+        handleRecommendedQuery={(query) =>
+          handleRecommendedQuery(
+            query,
+            language,
+            selectedCharacter,
+            messages,
+            setMessages,
+            setInputMessage,
+            formatTime
+          )
+        }
         getRarityColor={getRarityColor}
       />
     );
   }
 
-  // 관람 후기 페이지
-  if (currentPage === 'summary') {
+  if (currentPage === "summary") {
     return (
       <FavoriteSelectPage
             language={language}
@@ -208,7 +300,7 @@ export default function App() {
       />
     );
   }
-  // 캐릭터 선택 페이지
+
   return (
     <CharacterSelectPage
       language={language}

--- a/src/api/conversationMessagesApi.js
+++ b/src/api/conversationMessagesApi.js
@@ -1,36 +1,50 @@
-// src/api/conversationsApi.js
-// Conversations API client for starting a new conversation session
+// src/api/conversationMessagesApi.js
+// Conversation messages API client for posting a new message to a conversation
+
+import { API_BASE_URL } from "./conversationsApi";
 
 /**
- * Resolve backend base URL from Vite env or fallback to provided Azure host.
- * Ensures there is no trailing slash.
- */
-const API_BASE_URL = (import.meta?.env?.VITE_BACKEND_URL || "https://yerak-chat-cyfze4hnhbeaawc8.koreacentral-01.azurewebsites.net").replace(/\/$/, "");
-
-/**
- * POST /api/conversations
- * Starts a new conversation session.
+ * POST /api/conversations/{conversationId}/messages
+ * Posts a message to an existing conversation.
  *
+ * @param {number|string} conversationId - Conversation/session identifier
+ * @param {{ role?: 'USER'|'ASSISTANT'|'SYSTEM', content: string }} body - Message payload
  * @param {Object} [options]
  * @param {Object} [options.headers] - Additional headers to merge
  * @param {number} [options.timeoutMs=15000] - Request timeout in milliseconds
- * @returns {Promise<{ success: boolean; data?: { sessionId: number; status: string; startedAt: string }; error?: { code?: string; message?: string; details?: any }; timestamp?: string }>} Parsed API response
+ * @returns {Promise<{ success: boolean; data?: { messageId: number; sessionId: number; role: string; content: string; createdAt: string; assistantPreview?: string }; error?: { code?: string; message?: string; details?: any }; timestamp?: string }>} Parsed API response
  */
-export async function startConversation(options = {}) {
+export async function postConversationMessage(conversationId, body, options = {}) {
   const { headers = {}, timeoutMs = 15000 } = options;
+
+  if (conversationId == null || conversationId === "") {
+    return {
+      success: false,
+      error: { code: "INVALID_ARGUMENT", message: "conversationId is required" },
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  if (!body || !body.content || typeof body.content !== "string") {
+    return {
+      success: false,
+      error: { code: "INVALID_ARGUMENT", message: "body.content (string) is required" },
+      timestamp: new Date().toISOString(),
+    };
+  }
 
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const response = await fetch(`${API_BASE_URL}/api/conversations`, {
+    const response = await fetch(`${API_BASE_URL}/api/conversations/${encodeURIComponent(conversationId)}/messages`, {
       method: "POST",
       headers: {
         Accept: "application/json",
         "Content-Type": "application/json",
         ...headers,
       },
-      body: JSON.stringify({}),
+      body: JSON.stringify({ role: body.role ?? "USER", content: body.content }),
       signal: controller.signal,
     });
 
@@ -54,7 +68,6 @@ export async function startConversation(options = {}) {
       throw Object.assign(new Error(message), { response, payload: error });
     }
 
-    // Return parsed JSON (swagger-style shape expected)
     return payload;
   } catch (err) {
     if (err?.name === "AbortError") {
@@ -62,7 +75,7 @@ export async function startConversation(options = {}) {
         success: false,
         error: {
           code: "TIMEOUT",
-          message: `startConversation timed out after ${timeoutMs}ms`,
+          message: `postConversationMessage timed out after ${timeoutMs}ms`,
         },
         timestamp: new Date().toISOString(),
       };
@@ -81,7 +94,5 @@ export async function startConversation(options = {}) {
     clearTimeout(timeout);
   }
 }
-
-export { API_BASE_URL };
 
 


### PR DESCRIPTION
- Fix startConversation API to use session_id instead of sessionId (snake_case vs camelCase)
- Add comprehensive conversation API clients (start, messages, details, end)
- Integrate conversation history loading on chat start with graceful fallback
- Add proper error handling for conversation history (first chat scenario)
- Wire message posting to backend with assistantPreview support
- Connect end conversation API to chat termination flow
- Remove conversation parameters as per API specification (no body required)
- Add system messages for session start/offline mode indication